### PR TITLE
Modernize dropbox-sync for Dropbox API v2 and current Supervisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,28 @@
-# Hass.io Add-ons for Home Assistant
+# Home Assistant Add-ons
 
-[![License][license-shield]](LICENSE.md)
+[![License][license-shield]](LICENSE)
 
-## About
-
-This repository collects all of my Hass.io add-ons for easier installation.
+A small personal repository of Home Assistant add-ons.
 
 ## Installation
 
-Follow [the official instructions](https://home-assistant.io/hassio/installing_third_party_addons/) on the Home Assistant website and use the following URL:
-```txt
-https://github.com/danielwelch/hassio-addons
-```
+In Home Assistant, go to **Settings → Add-ons → Add-on Store → ⋮ → Repositories**
+and add the URL of this repository. The add-ons below will then appear in the
+store and the Supervisor will build them on your device on first install.
 
-## Add-ons provided by this repository
+## Add-ons
 
-### [Dropbox Sync][addon-dropbox-sync]
+### [Dropbox Sync](./dropbox-sync)
 
-![Supports armhf Architecture][dropbox-sync-armhf-shield]
-![Supports aarch64 Architecture][dropbox-sync-aarch64-shield]
-![Supports amd64 Architecture][dropbox-sync-amd64-shield]
-![Supports i386 Architecture][dropbox-sync-i386-shield]
-![Docker Pulls][dropbox-sync-pulls-shield]
+Upload your Home Assistant backups to Dropbox. Uses Dropbox API v2 with the
+modern refresh-token OAuth flow. See [the add-on README](./dropbox-sync/README.md)
+for setup.
 
-Upload your Hass.io backups to Dropbox.
+## Credit
 
-[:books: Dropbox Sync add-on documentation][addon-dropbox-sync]
+The original `dropbox-sync` add-on is by [@danielwelch][upstream]. This
+repository is a personal fork that modernizes it for Dropbox API v2 and the
+current Home Assistant Supervisor.
 
-[addon-dropbox-sync]: https://github.com/danielwelch/hassio-dropbox-sync
-[dropbox-sync-armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg?style=flat
-[dropbox-sync-aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg?style=flat
-[dropbox-sync-amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg?style=flat
-[dropbox-sync-i386-shield]: https://img.shields.io/badge/i386-yes-green.svg?style=flat
-[dropbox-sync-pulls-shield]: https://img.shields.io/docker/pulls/dwelch2101/dropbox-sync-armhf.svg?style=flat
-[license-shield]: https://img.shields.io/github/license/danielwelch/hassio-addons.svg?style=flat
+[upstream]: https://github.com/danielwelch/hassio-dropbox-sync
+[license-shield]: https://img.shields.io/badge/license-MIT-blue.svg?style=flat

--- a/dropbox-sync/Dockerfile
+++ b/dropbox-sync/Dockerfile
@@ -1,0 +1,22 @@
+ARG BUILD_FROM
+FROM $BUILD_FROM
+
+ENV LANG=C.UTF-8
+
+# Pinned to a known-good commit of andreafabrizi/Dropbox-Uploader (API v2 + refresh tokens).
+ARG DROPBOX_UPLOADER_SHA=11fb8f736064730dd21ff85d68dfcc8aacfdf559
+
+RUN apk add --no-cache bash jq curl findutils python3 py3-requests py3-dateutil py3-tz
+
+RUN curl -fsSL \
+        "https://raw.githubusercontent.com/andreafabrizi/Dropbox-Uploader/${DROPBOX_UPLOADER_SHA}/dropbox_uploader.sh" \
+        -o /dropbox_uploader.sh \
+    && chmod a+x /dropbox_uploader.sh
+
+COPY run.sh /
+COPY keep_last.py /
+RUN chmod a+x /run.sh
+
+WORKDIR /
+
+CMD [ "/run.sh" ]

--- a/dropbox-sync/README.md
+++ b/dropbox-sync/README.md
@@ -1,0 +1,85 @@
+# Dropbox Sync
+
+Upload your Home Assistant backups (and optionally files from `/share`) to
+Dropbox.
+
+This add-on is built locally by the Home Assistant Supervisor from the source
+in this directory — there is no published Docker image. First install takes a
+couple of minutes; subsequent updates are fast.
+
+## What changed in 2.0.0
+
+Dropbox shut down API v1 in 2017 and stopped issuing long-lived access tokens
+shortly after, which is why the 1.x add-on stopped working. 2.0.0 uses Dropbox
+API v2 with the modern refresh-token OAuth flow.
+
+The configuration schema changed. You now provide an `app_key`, `app_secret`,
+and `refresh_token` instead of a single `oauth_access_token`. See below.
+
+## One-time setup
+
+### 1. Create a Dropbox app
+
+Go to <https://www.dropbox.com/developers/apps> and click **Create app**.
+
+- **API:** Scoped access
+- **Access type:** App folder (recommended — keeps the add-on sandboxed
+  to a single folder) or Full Dropbox if you prefer
+- **Name:** anything you like
+
+On the new app's page:
+
+- Under **Permissions**, enable at minimum `files.content.write` and
+  `files.content.read`. Click **Submit**.
+- Under **Settings**, copy the **App key** and **App secret**.
+
+### 2. Generate a refresh token
+
+On any machine with Python 3 and a browser:
+
+```sh
+python3 dropbox-sync/get_refresh_token.py
+```
+
+Paste the app key and secret when prompted. Your browser opens to a Dropbox
+authorization page; approve it and copy the authorization code back into the
+terminal. The script prints your `refresh_token`.
+
+### 3. Configure the add-on
+
+In the add-on's Configuration tab:
+
+```yaml
+app_key: "<your app key>"
+app_secret: "<your app secret>"
+refresh_token: "<the refresh token from step 2>"
+output: "/"            # path inside Dropbox; "/" means the app folder root
+keep_last: 5           # optional: prune backups to the N newest
+filetypes: "jpg|png"   # optional: also upload matching files from /share
+```
+
+Restart the add-on.
+
+## Usage
+
+The add-on listens on stdin for service calls. To trigger an upload, call the
+`hassio.addon_stdin` service from an automation:
+
+```yaml
+service: hassio.addon_stdin
+data:
+  addon: local_dropbox_sync
+  input:
+    command: upload
+```
+
+(The slug is `local_dropbox_sync` when the Supervisor builds it locally from
+this repo.)
+
+## Notes
+
+- The Dropbox uploader script (`dropbox_uploader.sh`) is pinned to a specific
+  commit at image build time so a future upstream change cannot silently break
+  this add-on the way it did before.
+- `keep_last` uses the current Supervisor backups API (`/backups`), not the
+  legacy `/snapshots` endpoint.

--- a/dropbox-sync/config.json
+++ b/dropbox-sync/config.json
@@ -1,14 +1,15 @@
 {
   "name": "Dropbox Sync",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "slug": "dropbox_sync",
-  "description": "Upload your Hass.io backups to Dropbox",
+  "description": "Upload your Home Assistant backups to Dropbox",
   "url": "https://github.com/danielwelch/hassio-dropbox-sync",
   "startup": "before",
-    "arch": [
+  "arch": [
     "aarch64",
     "amd64",
     "armhf",
+    "armv7",
     "i386"
   ],
   "stdin": true,
@@ -17,14 +18,17 @@
   "boot": "auto",
   "map": ["backup", "share"],
   "options": {
-    "oauth_access_token": "<YOUR_ACCESS_TOKEN>",
+    "app_key": "",
+    "app_secret": "",
+    "refresh_token": "",
     "output": ""
   },
   "schema": {
-    "oauth_access_token": "str",
+    "app_key": "str",
+    "app_secret": "str",
+    "refresh_token": "str",
     "output": "str",
     "keep_last": "int(0,)?",
     "filetypes": "str?"
-  },
-  "image": "dwelch2101/dropbox-sync-{arch}"
+  }
 }

--- a/dropbox-sync/get_refresh_token.py
+++ b/dropbox-sync/get_refresh_token.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""One-time helper: mint a Dropbox refresh token from an app key/secret.
+
+Run this once on any machine with a browser available. It prints the
+refresh_token you should paste into the add-on configuration.
+
+Requires only the Python standard library.
+"""
+import getpass
+import json
+import sys
+import urllib.parse
+import urllib.request
+import webbrowser
+
+
+def main() -> int:
+    print("Dropbox refresh token helper")
+    print("---------------------------")
+    print("Create an app at https://www.dropbox.com/developers/apps if you")
+    print("haven't already. Choose 'Scoped access' and 'App folder' (or")
+    print("'Full Dropbox' if you want the add-on to write anywhere).")
+    print("Grant at least the files.content.write and files.content.read")
+    print("scopes. Then copy the App key and App secret below.\n")
+
+    app_key = input("App key: ").strip()
+    app_secret = getpass.getpass("App secret (hidden): ").strip()
+    if not app_key or not app_secret:
+        print("App key and app secret are required.", file=sys.stderr)
+        return 1
+
+    authorize_url = (
+        "https://www.dropbox.com/oauth2/authorize?"
+        + urllib.parse.urlencode(
+            {
+                "client_id": app_key,
+                "response_type": "code",
+                "token_access_type": "offline",
+            }
+        )
+    )
+    print("\nOpening Dropbox authorization page in your browser...")
+    print("If it does not open, visit this URL manually:")
+    print(authorize_url, "\n")
+    try:
+        webbrowser.open(authorize_url)
+    except webbrowser.Error:
+        pass
+
+    auth_code = input("Paste the authorization code from Dropbox: ").strip()
+    if not auth_code:
+        print("Authorization code is required.", file=sys.stderr)
+        return 1
+
+    body = urllib.parse.urlencode(
+        {
+            "code": auth_code,
+            "grant_type": "authorization_code",
+            "client_id": app_key,
+            "client_secret": app_secret,
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        "https://api.dropbox.com/oauth2/token",
+        data=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.load(resp)
+    except urllib.error.HTTPError as e:
+        print(f"Dropbox rejected the code: {e.code} {e.read().decode()}", file=sys.stderr)
+        return 1
+
+    refresh_token = payload.get("refresh_token")
+    if not refresh_token:
+        print("Dropbox did not return a refresh_token. Response was:", file=sys.stderr)
+        print(json.dumps(payload, indent=2), file=sys.stderr)
+        return 1
+
+    print("\nSuccess. Paste the following into your add-on configuration:\n")
+    print(f"  app_key:       {app_key}")
+    print(f"  app_secret:    {app_secret}")
+    print(f"  refresh_token: {refresh_token}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dropbox-sync/keep_last.py
+++ b/dropbox-sync/keep_last.py
@@ -1,0 +1,45 @@
+"""Prune old Home Assistant backups, keeping only the N newest."""
+import argparse
+import os
+import sys
+
+import pytz
+import requests
+from dateutil.parser import parse
+
+BASE_URL = "http://supervisor/"
+HEADERS = {"Authorization": "Bearer " + os.environ.get("SUPERVISOR_TOKEN", "")}
+
+
+def main(number_to_keep: int) -> None:
+    resp = requests.get(BASE_URL + "backups", headers=HEADERS, timeout=30)
+    resp.raise_for_status()
+    backups = resp.json()["data"]["backups"]
+
+    for b in backups:
+        d = parse(b["date"])
+        if d.tzinfo is None or d.tzinfo.utcoffset(d) is None:
+            print(f"Naive datetime for backup {b['slug']}, treating as UTC")
+            b["date"] = d.replace(tzinfo=pytz.utc).isoformat()
+
+    backups.sort(key=lambda item: parse(item["date"]), reverse=True)
+    stale = backups[number_to_keep:]
+
+    for b in stale:
+        url = BASE_URL + "backups/" + b["slug"]
+        res = requests.delete(url, headers=HEADERS, timeout=30)
+        if res.ok:
+            print(f"[Info] Deleted backup {b['slug']}")
+        else:
+            print(
+                f"[Error] Failed to delete backup {b['slug']}: "
+                f"{res.status_code} {res.text}",
+                file=sys.stderr,
+            )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Remove old Home Assistant backups.")
+    parser.add_argument("number", type=int, help="Number of backups to keep")
+    args = parser.parse_args()
+    main(args.number)

--- a/dropbox-sync/run.sh
+++ b/dropbox-sync/run.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -euo pipefail
+
+CONFIG_PATH=/data/options.json
+UPLOADER_CONF=/etc/uploader.conf
+
+APP_KEY=$(jq --raw-output '.app_key // empty' "$CONFIG_PATH")
+APP_SECRET=$(jq --raw-output '.app_secret // empty' "$CONFIG_PATH")
+REFRESH_TOKEN=$(jq --raw-output '.refresh_token // empty' "$CONFIG_PATH")
+OUTPUT_DIR=$(jq --raw-output '.output // empty' "$CONFIG_PATH")
+KEEP_LAST=$(jq --raw-output '.keep_last // empty' "$CONFIG_PATH")
+FILETYPES=$(jq --raw-output '.filetypes // empty' "$CONFIG_PATH")
+
+if [[ -z "$APP_KEY" || -z "$APP_SECRET" || -z "$REFRESH_TOKEN" ]]; then
+    echo "[Error] app_key, app_secret, and refresh_token are all required."
+    echo "[Error] See the add-on README for how to generate them."
+    exit 1
+fi
+
+if [[ -z "$OUTPUT_DIR" ]]; then
+    OUTPUT_DIR="/"
+fi
+
+echo "[Info] Files will be uploaded to: ${OUTPUT_DIR}"
+
+# Write the v2.0 config consumed by dropbox_uploader.sh.
+umask 077
+cat > "$UPLOADER_CONF" <<EOF
+CONFIGFILE_VERSION=2.0
+OAUTH_APP_KEY=${APP_KEY}
+OAUTH_APP_SECRET=${APP_SECRET}
+OAUTH_REFRESH_TOKEN=${REFRESH_TOKEN}
+OAUTH_ACCESS_TOKEN=
+OAUTH_ACCESS_TOKEN_EXPIRE=0
+EOF
+
+uploader() {
+    /dropbox_uploader.sh -s -f "$UPLOADER_CONF" "$@"
+}
+
+echo "[Info] Listening for messages via stdin service call..."
+
+while read -r msg; do
+    echo "$msg"
+    cmd="$(echo "$msg" | jq --raw-output '.command')"
+    echo "[Info] Received message with command ${cmd}"
+
+    if [[ "$cmd" = "upload" ]]; then
+        echo "[Info] Uploading all .tar files in /backup (skipping those already in Dropbox)"
+        shopt -s nullglob
+        for f in /backup/*.tar; do
+            uploader upload "$f" "$OUTPUT_DIR" || echo "[Warn] Upload failed for $f"
+        done
+        shopt -u nullglob
+
+        if [[ -n "$KEEP_LAST" ]]; then
+            echo "[Info] keep_last option is set, cleaning up old backups..."
+            python3 /keep_last.py "$KEEP_LAST" || echo "[Warn] keep_last cleanup failed"
+        fi
+
+        if [[ -n "$FILETYPES" ]]; then
+            echo "[Info] filetypes option is set, scanning /share for extensions: ${FILETYPES}"
+            find /share -regextype posix-extended -regex "^.*\.(${FILETYPES})\$" -print0 \
+                | while IFS= read -r -d '' f; do
+                    uploader upload "$f" "$OUTPUT_DIR" || echo "[Warn] Upload failed for $f"
+                done
+        fi
+    else
+        echo "[Error] Command not found: ${cmd}"
+    fi
+done


### PR DESCRIPTION
The 1.x add-on stopped working because Dropbox shut down API v1 (the /upload and /chunked_upload endpoints) in 2017 and the published image (dwelch2101/dropbox-sync-*:1.3.0, last pushed 2018-10-05) baked in an API-v1 version of dropbox_uploader.sh. Long-lived OAuth access tokens were also deprecated.

Rewrite to a locally-built add-on (no published image, Supervisor builds on device) using Dropbox API v2 with the refresh-token OAuth flow:

- dropbox-sync/Dockerfile: pin dropbox_uploader.sh to a known-good commit so an upstream change cannot silently break us again.
- dropbox-sync/run.sh: write a v2.0 uploader.conf with OAUTH_APP_KEY, OAUTH_APP_SECRET, and OAUTH_REFRESH_TOKEN; the uploader script handles token refresh automatically.
- dropbox-sync/keep_last.py: update to current Supervisor API (http://supervisor/, Bearer SUPERVISOR_TOKEN, /backups endpoint).
- dropbox-sync/get_refresh_token.py: one-time stdlib helper that runs the OAuth dance and prints a refresh_token.
- dropbox-sync/config.json: drop `image:` so Supervisor builds locally, replace oauth_access_token with app_key/app_secret/refresh_token, add armv7 arch, bump to 2.0.0.
- README updates with setup instructions.